### PR TITLE
Allow choice of API

### DIFF
--- a/src/desktop/ofxRtMidiIn.cpp
+++ b/src/desktop/ofxRtMidiIn.cpp
@@ -14,7 +14,7 @@ ofPtr<RtMidiIn> ofxRtMidiIn::s_midiIn;
 
 // -----------------------------------------------------------------------------
 ofxRtMidiIn::ofxRtMidiIn(const string name, ofxMidiApi api) :
-	ofxBaseMidiIn(name), midiIn((RtMidi::Api) api, name) {
+	ofxBaseMidiIn(name, api), midiIn((RtMidi::Api) api, name) {
 }
 
 // -----------------------------------------------------------------------------

--- a/src/desktop/ofxRtMidiIn.cpp
+++ b/src/desktop/ofxRtMidiIn.cpp
@@ -13,8 +13,8 @@
 ofPtr<RtMidiIn> ofxRtMidiIn::s_midiIn;
 
 // -----------------------------------------------------------------------------
-ofxRtMidiIn::ofxRtMidiIn(const string name) :
-	ofxBaseMidiIn(name), midiIn(RtMidi::UNSPECIFIED, name) {
+ofxRtMidiIn::ofxRtMidiIn(const string name, ofxMidiApi api) :
+	ofxBaseMidiIn(name), midiIn((RtMidi::Api) api, name) {
 }
 
 // -----------------------------------------------------------------------------

--- a/src/desktop/ofxRtMidiIn.h
+++ b/src/desktop/ofxRtMidiIn.h
@@ -17,7 +17,7 @@ class ofxRtMidiIn : public ofxBaseMidiIn {
 
 public:
 
-	ofxRtMidiIn(const string name);
+	ofxRtMidiIn(const string name, ofxMidiApi api);
 	virtual ~ofxRtMidiIn();
 
 	static void listPorts();

--- a/src/desktop/ofxRtMidiOut.cpp
+++ b/src/desktop/ofxRtMidiOut.cpp
@@ -14,7 +14,7 @@ ofPtr<RtMidiOut> ofxRtMidiOut::s_midiOut;
 
 // -----------------------------------------------------------------------------
 ofxRtMidiOut::ofxRtMidiOut(const string name, ofxMidiApi api) :
-	ofxBaseMidiOut(name), midiOut((RtMidi::Api) api, name) {
+	ofxBaseMidiOut(name, api), midiOut((RtMidi::Api) api, name) {
 }
 
 // -----------------------------------------------------------------------------

--- a/src/desktop/ofxRtMidiOut.cpp
+++ b/src/desktop/ofxRtMidiOut.cpp
@@ -13,8 +13,8 @@
 ofPtr<RtMidiOut> ofxRtMidiOut::s_midiOut;
 
 // -----------------------------------------------------------------------------
-ofxRtMidiOut::ofxRtMidiOut(const string name) :
-	ofxBaseMidiOut(name), midiOut(RtMidi::UNSPECIFIED, name) {
+ofxRtMidiOut::ofxRtMidiOut(const string name, ofxMidiApi api) :
+	ofxBaseMidiOut(name), midiOut((RtMidi::Api) api, name) {
 }
 
 // -----------------------------------------------------------------------------

--- a/src/desktop/ofxRtMidiOut.h
+++ b/src/desktop/ofxRtMidiOut.h
@@ -17,8 +17,8 @@ class ofxRtMidiOut : public ofxBaseMidiOut {
 
 public:
 
-	/// set the output client name (optional)
-	ofxRtMidiOut(const string name);
+	/// set the output client name and api (optional)
+	ofxRtMidiOut(const string name, ofxMidiApi api);
 	virtual ~ofxRtMidiOut();
 
 	static void listPorts();

--- a/src/ios/ofxPGMidiIn.h
+++ b/src/ios/ofxPGMidiIn.h
@@ -19,7 +19,7 @@ class ofxPGMidiIn : public ofxBaseMidiIn {
 
 public:
 
-	ofxPGMidiIn(const string name);
+	ofxPGMidiIn(const string name, ofxMidiApi api);
 	virtual ~ofxPGMidiIn();
 
 	static void listPorts();

--- a/src/ios/ofxPGMidiIn.mm
+++ b/src/ios/ofxPGMidiIn.mm
@@ -19,7 +19,7 @@ struct ofxPGMidiIn::InputDelegate {
 };
 
 // -----------------------------------------------------------------------------
-ofxPGMidiIn::ofxPGMidiIn(const string name) : ofxBaseMidiIn(name) {
+ofxPGMidiIn::ofxPGMidiIn(const string name, ofxMidiApi api) : ofxBaseMidiIn(name) {
 
 	// setup global midi instance
 	ofxPGMidiContext::setup();

--- a/src/ios/ofxPGMidiOut.h
+++ b/src/ios/ofxPGMidiOut.h
@@ -16,7 +16,7 @@ class ofxPGMidiOut : public ofxBaseMidiOut {
 
 public:
 
-	ofxPGMidiOut(const string name);
+	ofxPGMidiOut(const string name, ofxMidiApi api);
 	virtual ~ofxPGMidiOut();
 	
 	static void listPorts();

--- a/src/ios/ofxPGMidiOut.mm
+++ b/src/ios/ofxPGMidiOut.mm
@@ -18,7 +18,7 @@ struct ofxPGMidiOut::Destination {
 };
 
 // -----------------------------------------------------------------------------
-ofxPGMidiOut::ofxPGMidiOut(const string name) : ofxBaseMidiOut(name) {
+ofxPGMidiOut::ofxPGMidiOut(const string name, ofxMidiApi api) : ofxBaseMidiOut(name) {
 	
 	// setup global midi instance
 	ofxPGMidiContext::setup();

--- a/src/ofxBaseMidi.cpp
+++ b/src/ofxBaseMidi.cpp
@@ -15,7 +15,7 @@
 vector<string> ofxBaseMidiIn::portList;
 
 // -----------------------------------------------------------------------------
-ofxBaseMidiIn::ofxBaseMidiIn(const string name) {
+ofxBaseMidiIn::ofxBaseMidiIn(const string name, ofxMidiApi api) : bApi(api) {
 	portNum = -1;
 	portName = "";
 	bOpen = false;
@@ -40,6 +40,11 @@ bool ofxBaseMidiIn::isOpen() {
 // -----------------------------------------------------------------------------
 bool ofxBaseMidiIn::isVirtual() {
 	return bVirtual;
+}
+
+// -----------------------------------------------------------------------------
+ofxMidiApi ofxBaseMidiIn::getApi() {
+	return bApi;
 }
 
 // -----------------------------------------------------------------------------
@@ -79,7 +84,7 @@ void ofxBaseMidiIn::manageNewMessage(double deltatime, vector<unsigned char> *me
 vector<string> ofxBaseMidiOut::portList;
 
 // -----------------------------------------------------------------------------
-ofxBaseMidiOut::ofxBaseMidiOut(const string name) {
+ofxBaseMidiOut::ofxBaseMidiOut(const string name, ofxMidiApi api) : bApi(api) {
 	portNum = -1;
 	portName = "";
 	bOpen = false;
@@ -105,6 +110,11 @@ bool ofxBaseMidiOut::isOpen() {
 // -----------------------------------------------------------------------------
 bool ofxBaseMidiOut::isVirtual() {
 	return bVirtual;
+}
+
+// -----------------------------------------------------------------------------
+ofxMidiApi ofxBaseMidiOut::getApi() {
+	return bApi;
 }
 
 // -----------------------------------------------------------------------------

--- a/src/ofxBaseMidi.h
+++ b/src/ofxBaseMidi.h
@@ -25,7 +25,7 @@ class ofxBaseMidiIn {
 
 public:
 
-	ofxBaseMidiIn(const string name);
+	ofxBaseMidiIn(const string name, ofxMidiApi api);
 	virtual ~ofxBaseMidiIn() {}
 	
 	virtual bool openPort(unsigned int portNumber) = 0;
@@ -37,6 +37,7 @@ public:
 	string getName();
 	bool isOpen();
 	bool isVirtual();
+	ofxMidiApi getApi();
 
 	virtual void ignoreTypes(bool midiSysex=true, bool midiTiming=true,
 	                         bool midiSense=true) = 0;
@@ -57,9 +58,10 @@ protected:
 	static vector<string> portList; //< list of port names
 	ofEvent<ofxMidiMessage> newMessageEvent;
 	
-	bool bOpen;    //< is the port currently open?
-	bool bVerbose; //< print incoming bytes?
-	bool bVirtual; //< are we connected to a virtual port?
+	bool bOpen;      //< is the port currently open?
+	bool bVerbose;   //< print incoming bytes?
+	bool bVirtual;   //< are we connected to a virtual port?
+	ofxMidiApi bApi; //< which backend API are we using?
 };
 
 /// a midi output port
@@ -70,7 +72,7 @@ class ofxBaseMidiOut {
 
 public:
 
-	ofxBaseMidiOut(const string name);
+	ofxBaseMidiOut(const string name, ofxMidiApi api);
 	virtual ~ofxBaseMidiOut() {}
 	
 	virtual bool openPort(unsigned int portNumber=0) = 0;
@@ -82,6 +84,7 @@ public:
 	string getName();
 	bool isOpen();
 	bool isVirtual();
+	ofxMidiApi getApi();
 	
 	void sendNoteOn(int channel, int pitch, int velocity);
 	void sendNoteOff(int channel, int pitch, int velocity);
@@ -112,4 +115,5 @@ protected:
 	bool bOpen;          //< is the port currently open?
 	bool bMsgInProgress; //< used with byte stream
 	bool bVirtual;       //< are we connected to a virtual port?
+	ofxMidiApi bApi;     //< which backend API are we using?
 };

--- a/src/ofxMidiIn.cpp
+++ b/src/ofxMidiIn.cpp
@@ -11,8 +11,8 @@
 #include "ofxMidiIn.h"
 
 // -----------------------------------------------------------------------------
-ofxMidiIn::ofxMidiIn(const string name) {
-	midiIn = ofPtr<ofxBaseMidiIn>(new OFX_MIDI_IN_TYPE(name));
+ofxMidiIn::ofxMidiIn(const string name, ofxMidiApi api) {
+	midiIn = ofPtr<ofxBaseMidiIn>(new OFX_MIDI_IN_TYPE(name, api));
 }
 
 // -----------------------------------------------------------------------------

--- a/src/ofxMidiIn.h
+++ b/src/ofxMidiIn.h
@@ -52,9 +52,8 @@
 class ofxMidiIn {
 
 public:
-
 	/// set the input client name (optional)
-	ofxMidiIn(const string name="ofxMidiIn Client");
+	ofxMidiIn(const string name="ofxMidiIn Client", ofxMidiApi api = OFXMIDI_UNSPECIFIED);
 	virtual ~ofxMidiIn();
 	
 /// \section Global Port Info

--- a/src/ofxMidiOut.cpp
+++ b/src/ofxMidiOut.cpp
@@ -11,8 +11,8 @@
 #include "ofxMidiOut.h"
 
 // -----------------------------------------------------------------------------
-ofxMidiOut::ofxMidiOut(const string name) {
-	midiOut = ofPtr<ofxBaseMidiOut>(new OFX_MIDI_OUT_TYPE(name));
+ofxMidiOut::ofxMidiOut(const string name, ofxMidiApi api) {
+	midiOut = ofPtr<ofxBaseMidiOut>(new OFX_MIDI_OUT_TYPE(name, api));
 }
 
 // -----------------------------------------------------------------------------

--- a/src/ofxMidiOut.h
+++ b/src/ofxMidiOut.h
@@ -54,7 +54,7 @@ class ofxMidiOut {
 public:
 
 	/// set the output client name (optional)
-	ofxMidiOut(const string name="ofxMidiOut Client");
+	ofxMidiOut(const string name="ofxMidiOut Client", ofxMidiApi api = OFXMIDI_UNSPECIFIED);
 	virtual ~ofxMidiOut();
 	
 /// \section Global Port Info

--- a/src/ofxMidiTypes.h
+++ b/src/ofxMidiTypes.h
@@ -10,6 +10,27 @@
  */
 #pragma once
 
+#ifndef TARGET_OF_IPHONE
+    #include "RtMidi.h"
+#endif
+
+// MIDI backend APIs
+
+enum ofxMidiApi {
+
+#ifdef TARGET_OF_IPHONE
+    OFXMIDI_UNSPECIFIED,
+    OFXMIDI_PGMIDI,
+#else
+    OFXMIDI_UNSPECIFIED     = RtMidi::UNSPECIFIED,
+    OFXMIDI_MACOSX_CORE     = RtMidi::MACOSX_CORE,
+    OFXMIDI_LINUX_ALSA      = RtMidi::LINUX_ALSA,
+    OFXMIDI_UNIX_JACK       = RtMidi::UNIX_JACK,
+    OFXMIDI_WINDOWS_MM      = RtMidi::WINDOWS_MM,
+    OFXMIDI_DUMMY           = RtMidi::RTMIDI_DUMMY
+#endif
+};
+
 /// \section  stream interface midi objects
 /// ref: http://www.gweep.net/~prefect/eng/reference/protocol/midispec.html
 


### PR DESCRIPTION
Currently I cannot use the JACK backend because ALSA gets tried first and there is no way of passing the API i want to use to RtMidi.
This patch introduces a new enum ofxMidiApi with values like OFXMIDI_UNIX_JACK etc that map to the RtMidi APIs.

The static-ish methods of ofxRtMidiIn/ofxRtMidiOut like .listPorts() etc (everything using the `s_*` values) needs to be fixed still. I am not sure how to deal with it because of the static nature, the easiest would be to just drop the static methods since they internally create an instance of the wrapped class anyway.