### PR TITLE
fix cmath include in ofxMidiTimecode.cpp

### DIFF
--- a/src/ofxMidiTimecode.cpp
+++ b/src/ofxMidiTimecode.cpp
@@ -16,6 +16,7 @@
 #include "ofxMidi.h"
 #include <sstream>
 #include <iomanip>
+#include <cmath>
 
 // ofxMidiTimecodeFrame
 


### PR DESCRIPTION
Hey, the latest master doesn't build for me: 

```
/home/s-ol/Documents/osc/of/addons/ofxMidi/src/ofxMidiTimecode.cpp: In member function ‘void ofxMidiTimecodeFrame::fromSeconds(double, unsigned char)’:
/home/s-ol/Documents/osc/of/addons/ofxMidi/src/ofxMidiTimecode.cpp:58:31: error: ‘floor’ was not declared in this scope
  double ms = (int)(floor((s - floor(s)) * 100.0) + 0.5);
                               ^~~~~
/home/s-ol/Documents/osc/of/addons/ofxMidi/src/ofxMidiTimecode.cpp:58:31: note: suggested alternative: ‘float’
  double ms = (int)(floor((s - floor(s)) * 100.0) + 0.5);
                               ^~~~~
                               float
/home/s-ol/Documents/osc/of/addons/ofxMidi/src/ofxMidiTimecode.cpp:58:20: error: ‘floor’ was not declared in this scope
  double ms = (int)(floor((s - floor(s)) * 100.0) + 0.5);
                    ^~~~~
/home/s-ol/Documents/osc/of/addons/ofxMidi/src/ofxMidiTimecode.cpp:58:20: note: suggested alternative: ‘float’
  double ms = (int)(floor((s - floor(s)) * 100.0) + 0.5);
                    ^~~~~
                    float
/home/s-ol/Documents/osc/of/addons/ofxMidi/src/ofxMidiTimecode.cpp: In static member function ‘static unsigned char ofxMidiTimecode::fpsToRate(double)’:
/home/s-ol/Documents/osc/of/addons/ofxMidi/src/ofxMidiTimecode.cpp:112:18: error: ‘round’ was not declared in this scope
  int rate = (int)round(fps);
                  ^~~~~
/home/s-ol/Documents/osc/of/addons/ofxMidi/src/ofxMidiTimecode.cpp:112:18: note: suggested alternative: ‘rand’
  int rate = (int)round(fps);
                  ^~~~~
                  rand
/home/s-ol/Documents/osc/of/addons/ofxMidi/src/ofxMidiTimecode.cpp:112:6: warning: unused variable ‘rate’ [-Wunused-variable]
  int rate = (int)round(fps);
      ^~~~
```

it seems that all that's missing is an `#include <cmath>` though :)